### PR TITLE
v1.1.0

### DIFF
--- a/NamiSDKComboBinding/NamiSDKComboBinding/ApiDefinitions.cs
+++ b/NamiSDKComboBinding/NamiSDKComboBinding/ApiDefinitions.cs
@@ -414,7 +414,7 @@ namespace NamiML
 
 		// +(void)preparePaywallForDisplay: (Bool) backgroundImageRequired imageFetchTimeout: (Double) imageFetchTimeout :(void (^ _Nonnull)(Bool, NSerror*))prepareHandler;
 		[Static]
-		[Export("preparePaywallForDisplayByDeveloperPaywallId:backgroundImageRequired:imageFetchTimeout:prepareHandler:")]
+		[Export("preparePaywallForDisplayWithDeveloperPaywallID:backgroundImageRequired:imageFetchTimeout:prepareHandler:")]
 		void PreparePaywallForDisplayByDeveloperPaywallID(string developerPaywallID, bool backgroundImageRequired, double imageFetchTimeout, Action<bool, NSError>  prepareHandler);
 
 		// +(void)raisePaywallFromVC:(UIViewController * _Nullable)fromVC;

--- a/NamiSDKComboBinding/NamiSDKComboBinding/ApiDefinitions.cs
+++ b/NamiSDKComboBinding/NamiSDKComboBinding/ApiDefinitions.cs
@@ -407,6 +407,16 @@ namespace NamiML
 		[Export("canRaisePaywall")]
 		bool CanRaisePaywall { get; }
 
+		// +(void)preparePaywallForDisplay:(NSString *)developerPaywallID backgroundImageRequired: (Bool) backgroundImageRequired imageFetchTimeout: (Double) imageFetchTimeout :(void (^ _Nonnull)(Bool, NSerror*))prepareHandler;
+		[Static]
+		[Export("preparePaywallForDisplayWithBackgroundImageRequired:imageFetchTimeout:prepareHandler:")]
+		void PreparePaywallForDisplayWithBackgroundImageRequired(bool backgroundImageRequired, double imageFetchTimeout, Action<bool, NSError> prepareHandler);
+
+		// +(void)preparePaywallForDisplay: (Bool) backgroundImageRequired imageFetchTimeout: (Double) imageFetchTimeout :(void (^ _Nonnull)(Bool, NSerror*))prepareHandler;
+		[Static]
+		[Export("preparePaywallForDisplayByDeveloperPaywallId:backgroundImageRequired:imageFetchTimeout:prepareHandler:")]
+		void PreparePaywallForDisplayByDeveloperPaywallID(string developerPaywallID, bool backgroundImageRequired, double imageFetchTimeout, Action<bool, NSError>  prepareHandler);
+
 		// +(void)raisePaywallFromVC:(UIViewController * _Nullable)fromVC;
 		[Static]
 		[Export("raisePaywallFromVC:")]

--- a/NamiSDKComboBinding/NamiSDKComboBinding/ApiDefinitions.cs
+++ b/NamiSDKComboBinding/NamiSDKComboBinding/ApiDefinitions.cs
@@ -410,7 +410,7 @@ namespace NamiML
 		// +(void)preparePaywallForDisplay:(NSString *)developerPaywallID backgroundImageRequired: (Bool) backgroundImageRequired imageFetchTimeout: (Double) imageFetchTimeout :(void (^ _Nonnull)(Bool, NSerror*))prepareHandler;
 		[Static]
 		[Export("preparePaywallForDisplayWithBackgroundImageRequired:imageFetchTimeout:prepareHandler:")]
-		void PreparePaywallForDisplayWithBackgroundImageRequired(bool backgroundImageRequired, double imageFetchTimeout, Action<bool, NSError> prepareHandler);
+		void PreparePaywallForDisplay(bool backgroundImageRequired, double imageFetchTimeout, Action<bool, NSError> prepareHandler);
 
 		// +(void)preparePaywallForDisplay: (Bool) backgroundImageRequired imageFetchTimeout: (Double) imageFetchTimeout :(void (^ _Nonnull)(Bool, NSerror*))prepareHandler;
 		[Static]

--- a/NamiSDKComboBinding/NamiSDKComboBinding/NamiSDKComboBinding.csproj
+++ b/NamiSDKComboBinding/NamiSDKComboBinding/NamiSDKComboBinding.csproj
@@ -13,7 +13,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <PackOnBuild>true</PackOnBuild>
     <PackageId>NamiML.SDK</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <Authors>Nami ML</Authors>
     <Copyright>2021</Copyright>
     <PackageIconUrl>https://nami-brand.s3.amazonaws.com/images/Nami.SDK.2.0.120x137.png</PackageIconUrl>
@@ -23,6 +23,12 @@
     <Summary>Nami SDK Xamarin iOS Binding Library</Summary>
     <Title>Nami SDK Xamarin iOS Binding Library</Title>
     <Description>Xamarin iOS Binding Library for Nami SDK. Subscription and In-App Purchases Marketing Platform. Create no-code purchase journies, subscription management and customer CRM, and analytics. Simple integration. Monetize your App.</Description>
+    <PackageReleaseNotes>Added
+
+- Improved control over displaying paywalls and more clear errors when paywall cannot display with new preparePaywallForDisplay and preparePaywallForDisplayByDeveloperPaywallID methods
+
+SDK Version
+- nami-apple SDK v2.6.0</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/Xamarin-iOS-BasicSample/Xamarin-iOS-BasicSample/MainViewController.cs
+++ b/Samples/Xamarin-iOS-BasicSample/Xamarin-iOS-BasicSample/MainViewController.cs
@@ -237,7 +237,7 @@ namespace Xamarin_iOS_BasicSample
                }
                else
                {
-                   Console.WriteLine($"Error in image load for paywall: {error.LocalizedDescription}");
+                   Console.WriteLine($"Error preparing paywall for display: {error.LocalizedDescription}");
                }
            }); 
             

--- a/Samples/Xamarin-iOS-BasicSample/Xamarin-iOS-BasicSample/MainViewController.cs
+++ b/Samples/Xamarin-iOS-BasicSample/Xamarin-iOS-BasicSample/MainViewController.cs
@@ -229,7 +229,7 @@ namespace Xamarin_iOS_BasicSample
 
         private void OnSubscribeClicked(object sender, EventArgs e)
         {
-            NamiPaywallManager.PreparePaywallForDisplayWithBackgroundImageRequired(true, 10.0, (success, error) =>
+            NamiPaywallManager.PreparePaywallForDisplay(true, 10.0, (success, error) =>
            {
                if (success)
                {

--- a/Samples/Xamarin-iOS-BasicSample/Xamarin-iOS-BasicSample/MainViewController.cs
+++ b/Samples/Xamarin-iOS-BasicSample/Xamarin-iOS-BasicSample/MainViewController.cs
@@ -229,10 +229,18 @@ namespace Xamarin_iOS_BasicSample
 
         private void OnSubscribeClicked(object sender, EventArgs e)
         {
-            if (NamiPaywallManager.CanRaisePaywall)
-            {
-                NamiPaywallManager.RaisePaywall(this);
-            }
+            NamiPaywallManager.PreparePaywallForDisplayWithBackgroundImageRequired(true, 10.0, (success, error) =>
+           {
+               if (success)
+               {
+                   NamiPaywallManager.RaisePaywall(this);
+               }
+               else
+               {
+                   Console.WriteLine($"Error in image load for paywall: {error.LocalizedDescription}");
+               }
+           }); 
+            
         }
 
         private void OnAboutClicked(object sender, EventArgs e)


### PR DESCRIPTION
**Added**

- `PreparePaywallForDisplay` and `PreparePaywallForDisplayByDeveloperPaywallID` methods to provide more control over how paywalls are displayed

Apple SDK Version v2.6.0
[Release Notes](https://github.com/namiml/nami-apple/releases)